### PR TITLE
Add node_exporter-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   - [Scripting](#scripting)
 - [System Tools](#system-tools)
   - [Backups](#backups)
+  - [Prometheus exporters](#prometheus-exporters)
 - [Hardware](#hardware)
   - [Embedded](#embedded)
 - [Science](#science)
@@ -278,6 +279,10 @@ Also, unlike those above, which requires runtime dependancy, some pure-Nim libra
 ### Backups
 
 - [norg](https://codeberg.org/pswilde/norgbackup) - A portable wrapper for borg and restic.
+
+### Prometheus exporters
+
+- [node-exporter-lite](https://github.com/twekkel/node_exporter-lite) - An ultra‑light Prometheus [node_exporter](https://github.com/prometheus/node_exporter) replacement.
 
 
 ## Hardware


### PR DESCRIPTION
An ultra‑light Prometheus [node_exporter](https://github.com/prometheus/node_exporter) replacement, written in [Nim](https://nim-lang.org/). It compiles into a single static binary with zero external dependencies. You do not need Nim or GCC installed on your machine; that will be handled by the containerized build.

A minimal, high‑performance implementation of the standard node_exporter metrics with extremely low memory and CPU usage. Ideal for resource‑constrained systems, embedded devices, and environments where a compact, easy‑to‑distribute exporter is required.