### PR TITLE
Add jolt-nim

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ Also, unlike those above, which requires runtime dependancy, some pure-Nim libra
 ### Game Libraries
 
 - [nimgl](https://github.com/nimgl/nimgl) - NimGL is a Nim library that offers bindings for popular libraries used in computer graphics.
-- [jolt-nim](https://github.com/puffball1567/jolt-nim) - Native Nim bindings for Jolt Physics 5.6.0 with raw and ownership-safe high-level APIs. [MIT]
+- [jolt-nim](https://github.com/puffball1567/jolt-nim) - Native Nim bindings for Jolt Physics 5.6.0 with raw and ownership-safe high-level APIs [MIT].
 - [glm](https://github.com/stavenko/nim-glm) - Port of the popular glm C++ library to Nim.
 - [GLAD](https://github.com/Dav1dde/glad) - Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs.
 - [enu](https://github.com/dsrw/enu) - 3D live coding with a Logo-like DSL for Godot, implemented in Nim.

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ Also, unlike those above, which requires runtime dependancy, some pure-Nim libra
 ### Game Libraries
 
 - [nimgl](https://github.com/nimgl/nimgl) - NimGL is a Nim library that offers bindings for popular libraries used in computer graphics.
+- [jolt-nim](https://github.com/puffball1567/jolt-nim) - Native Nim bindings for Jolt Physics 5.6.0 with raw and ownership-safe high-level APIs. [MIT]
 - [glm](https://github.com/stavenko/nim-glm) - Port of the popular glm C++ library to Nim.
 - [GLAD](https://github.com/Dav1dde/glad) - Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs.
 - [enu](https://github.com/dsrw/enu) - 3D live coding with a Logo-like DSL for Godot, implemented in Nim.


### PR DESCRIPTION
## Summary

Add jolt-nim to Game Development / Game Libraries.

jolt-nim provides native Nim bindings for Jolt Physics 5.6.0, including complete low-level bindings and ownership-safe high-level APIs. It is MIT-licensed and has a stable v0.2.0 release, documentation, cross-platform tests, and interactive examples.